### PR TITLE
(GH-23) Update to get actual item before removing in list

### DIFF
--- a/chocolatey-diff/public/Get-ChocolateyPackageDiff.ps1
+++ b/chocolatey-diff/public/Get-ChocolateyPackageDiff.ps1
@@ -98,8 +98,8 @@ function Get-ChocolateyPackageDiff {
 
         Write-Host "Diff for ${file}:"
         Invoke-DiffTool -Path1 $oldItem -Path2 $newItem
-        while ($newItems -contains $newItem) {
-            $newItems.Remove($newItem)
+        while (($item = $newItems -eq $newItem | Select-Object -First 1)) {
+            $newItems.Remove($item)
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Due to powershell and C# code working a little differently in some cases,
there are some times a problem when using powershell to check if a list
contains an item, and then using C# to remove the actual item.
This is because a cast between a string and an object happens in C#
which makes it think the items are no longer equal and causes an
infinite loop.
This commit makes the necessary change to get the actual item in the
list before trying to remove the item, so no casting is automatically
performed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #23

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
So I could compare multiple files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally against the package `font-hackgen` package.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (I do not think it is necessary)
- [x] All new and existing tests passed.
