### PR TITLE
(GH-24) Add ability to compare directories

### DIFF
--- a/chocolatey-diff/public/Get-ChocolateyPackageDiff.ps1
+++ b/chocolatey-diff/public/Get-ChocolateyPackageDiff.ps1
@@ -32,6 +32,10 @@ function Get-ChocolateyPackageDiff {
 .PARAMETER KeepFiles
     OPTIONAL - Keep the downloaded files
 
+.PARAMETER CompareFolder
+    OPTIONAL - Pass in directories to compare instead of
+    files when calling Diff Tools.
+
 .EXAMPLE
     >
     Get-ChocolateyPackageDiff -packageName chocolatey -oldPackageVersion 0.10.14 -newPackageVersion 0.10.15
@@ -42,7 +46,8 @@ function Get-ChocolateyPackageDiff {
         [parameter(Mandatory = $false, Position = 1)][string] $oldPackageVersion,
         [parameter(Mandatory = $false, Position = 2)][string] $newPackageVersion,
         [parameter(Mandatory = $false)][string] $downloadLocation = $(Get-TempPath),
-        [parameter(Mandatory = $false)][switch] $keepFiles = $false
+        [parameter(Mandatory = $false)][switch] $keepFiles = $false,
+        [parameter(Mandatory = $false)][switch] $compareFolder = $false
     )
     $currentProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
@@ -79,39 +84,51 @@ function Get-ChocolateyPackageDiff {
     #Extract the package files
     Expand-Archive -Path $oldFileName -DestinationPath $oldExtractPath -Force
     Expand-Archive -Path $newFileName -DestinationPath $newExtractPath -Force
-    [System.Collections.ArrayList]$oldItems = (Get-ChildItem -Exclude $ignoreList -Path $oldExtractPath | Get-ChildItem -Recurse -File | Select-Object -Expand FullName)
-    [System.Collections.ArrayList]$newItems = (Get-ChildItem -Exclude $ignoreList -Path $newExtractPath | Get-ChildItem -Recurse -File | Select-Object -Expand FullName)
-    
-    ForEach ($oldItem in $oldItems) {
-        $file = $oldItem -replace [Regex]::Escape("${oldExtractPath}")
 
-        $newItem = $oldItem -replace $oldPackageVersion, $newPackageVersion
+    if ($compareFolder) {
+        # We need to remove files that should not be compared
+        $fullIgnoreList = $ignoreList | ForEach-Object { Join-Path $oldExtractPath $_ }
+        $fullIgnoreList += $ignoreList | ForEach-Object { Join-Path $newExtractPath $_ }
+        $fullIgnoreList | Where-Object { Test-Path $_ } | ForEach-Object { Remove-item $_ -Recurse -Force }
 
-        if (Test-IsBinary -Path $oldItem) {
-            Write-Warning "${file} is binary, ignoring." 
-            Continue
-        }
-
-        if (-Not (Test-Path $newItem -PathType Leaf)) {
-            Write-Warning "${file} does not exist in the new package"
-        }
-
-        Write-Host "Diff for ${file}:"
-        Invoke-DiffTool -Path1 $oldItem -Path2 $newItem
-        while (($item = $newItems -eq $newItem | Select-Object -First 1)) {
-            $newItems.Remove($item)
-        }
+        Write-Verbose "Diff for root directories"
+        Invoke-DiffTool -Path1 $oldExtractPath -Path2 $newExtractPath
     }
+    else {
+        [System.Collections.ArrayList]$oldItems = (Get-ChildItem -Exclude $ignoreList -Path $oldExtractPath | Get-ChildItem -Recurse -File | Select-Object -Expand FullName)
+        [System.Collections.ArrayList]$newItems = (Get-ChildItem -Exclude $ignoreList -Path $newExtractPath | Get-ChildItem -Recurse -File | Select-Object -Expand FullName)
 
-    ForEach ($newItem in $newItems) {
-        $file = $newItem -replace [Regex]::Escape("${newExtractPath}")
+        ForEach ($oldItem in $oldItems) {
+            $file = $oldItem -replace [Regex]::Escape("${oldExtractPath}")
 
-        if (Test-IsBinary -Path $newItem) {
-            Write-Warning "${file} is binary, ignoring." 
-            Continue
+            $newItem = $oldItem -replace $oldPackageVersion, $newPackageVersion
+
+            if (Test-IsBinary -Path $oldItem) {
+                Write-Warning "${file} is binary, ignoring." 
+                Continue
+            }
+
+            if (-Not (Test-Path $newItem -PathType Leaf)) {
+                Write-Warning "${file} does not exist in the new package"
+            }
+
+            Write-Host "Diff for ${file}:"
+            Invoke-DiffTool -Path1 $oldItem -Path2 $newItem
+            while ($newItems -contains $newItem) {
+                $newItems.Remove($newItem)
+            }
         }
 
-        Write-Warning "The ${file} is new. Manual verification required"
+        ForEach ($newItem in $newItems) {
+            $file = $newItem -replace [Regex]::Escape("${newExtractPath}")
+
+            if (Test-IsBinary -Path $newItem) {
+                Write-Warning "${file} is binary, ignoring." 
+                Continue
+            }
+
+            Write-Warning "The ${file} is new. Manual verification required"
+        }
     }
 
     if (-Not $keepFiles) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request adds the ability to compare directories instead of just single files.
This is made possible when the user passes in a new argument called `CompareFolder`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
resolves #24

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make comparison easier, and taking less time on lower powered computers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This have been tested in PowerShell 7.0.3 on Arch Linux (local computer), and using meld as the difftool.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
