### PR TITLE
(GH-22) Allow known differences to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can always specify the the diff-tool to use manually by utilizing the `env:d
 NOTE: Required for `-useDiffTool` parameter
 
 ```powershell
-choco install diffutils --source=cygwin
+choco install git
 ```
 
 ### On Linux/Mac
@@ -61,7 +61,7 @@ Import-Module .\chocolatey-diff\chocolatey-diff.psm1
 Get-ChocolateyPackageDiff ...
 ```
 
-By default, `C:\tools\cygwin\bin\diff.exe` is used on Windows OS and `diff` on Unix-like systems.
+By default, `C:\Program Files\Git\usr\bin\diff.exe` is used on Windows OS and `diff` on Unix-like systems.
 
 ## Example / Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This Powershell module allows you to view the diff of two package versions.
 
-## Requirements - diff tool
+## Requirements - diffutils
 
 This software requires you to have some diff-tool (such as kdiff3 or meld) package installed:
 You can always specify the the diff-tool to use manually by utilizing the `env:difftool` variable.
@@ -12,10 +12,10 @@ You can always specify the the diff-tool to use manually by utilizing the `env:d
 **On Windows:**
 
 ```powershell
-choco install kdiff3
+choco install diffutils --source=cygwin
 ```
 
-**On Linux/Mac** ensure at least `diff` and `unzip` are installed and available through PATH environment variable.
+**On Linux/Mac** ensure at least `diff` is installed and available through PATH environment variable.
 
 If you want to use a different diff-tool, set `env:difftool`:
 
@@ -25,7 +25,7 @@ Import-Module .\chocolatey-diff\chocolatey-diff.psm1
 Get-ChocolateyPackageDiff ...
 ```
 
-By default, `C:\Program Files\KDiff3\bin\diff.exe` is used on Windows OS and `diff` on Unix-like systems.
+By default, `C:\tools\cygwin\bin\diff.exe` is used on Windows OS and `diff` on Unix-like systems.
 
 ## Example / Usage
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@
 
 This Powershell module allows you to view the diff of two package versions.
 
+## Required - Powershell 6.0+
+
+### On Windows
+
+Easiest:
+
+```powershell
+choco install powershell-core
+```
+
+Other options:
+
+See this [document](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-7) from Microsoft to install POSH on Windows
+
+### On Mac
+
+Easiest:
+
+```sh
+brew cask install powershell
+```
+
+Other options:
+
+See this [document](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos?view=powershell-7) from Microsoft to install POSH on macOS
+
+### On Linux
+
+See this [document](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7) from Microsoft to install POSH on Linux.
+
 ## Optional - diffutils
 
 This software allows you to use some diff-tool (such as diff or meld):

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
-[![build](https://github.com/chocolatey-community/chocodiff/workflows/build/badge.svg)](https://github.com/chocolatey-community/chocodiff/actions?query=workflow%3Abuild)
-
 # Chocolatey Diff utility
+
+[![build](https://github.com/chocolatey-community/chocodiff/workflows/build/badge.svg)](https://github.com/chocolatey-community/chocodiff/actions?query=workflow%3Abuild)
 
 This Powershell module allows you to view the diff of two package versions.
 
-## Requirements - diffutils
+## Optional - diffutils
 
-This software requires you to have some diff-tool (such as kdiff3 or meld) package installed:
+This software allows you to use some diff-tool (such as diff or meld):
 You can always specify the the diff-tool to use manually by utilizing the `env:difftool` variable.
 
-**On Windows:**
+### On Windows
+
+NOTE: Required for `-useDiffTool` parameter
 
 ```powershell
 choco install diffutils --source=cygwin
 ```
 
-**On Linux/Mac** ensure at least `diff` is installed and available through PATH environment variable.
+### On Linux/Mac
+
+ensure at least `diff` is installed and available through PATH environment variable.
+
+### Optional
 
 If you want to use a different diff-tool, set `env:difftool`:
 
@@ -29,36 +35,35 @@ By default, `C:\tools\cygwin\bin\diff.exe` is used on Windows OS and `diff` on U
 
 ## Example / Usage
 
+### Syntax
+
+The Get-ChocolateyPacageDiff Syntax:
+
+```powershell
+Get-ChocolateyPackageDiff [-packageName] <string> [[-oldPackageVersion] <string>] [[-newPackageVersion] <string>] [-downloadLocation <string>] [-keepFiles] [-ignoreExpectedChanges] [<CommonParameters>]
+
+Get-ChocolateyPackageDiff [-packageName] <string> [[-oldPackageVersion] <string>] [[-newPackageVersion] <string>] [-downloadLocation <string>] [-keepFiles] [-compareFolder] [-useDiffTool] [<CommonParameters>]
+```
+
 ### Example: exact source and target version given
 
 ```powershell
 Import-Module .\chocolatey-diff\chocolatey-diff.psm1
-D:\Projects\chocolatey-diff [master ≡ +5 ~0 -0 !]> Get-ChocolateyPackageDiff -packageName grafana -oldPackageVersion 7.1.0 -newPackageVersion 7.1.1
-WARNING: Downloading file from https://chocolatey.org/api/v2/package/grafana/7.1.0
-WARNING: Downloading file from https://chocolatey.org/api/v2/package/grafana/7.1.1
+PS > Get-ChocolateyPackageDiff -packageName grafana -oldPackageVersion 7.1.0 -newPackageVersion 7.1.1
 Diff for \legal\LICENSE.txt:
 Diff for \legal\VERIFICATION.txt:
-9c9
-<   32-Bit: <https://dl.grafana.com/oss/release/grafana-7.1.0.windows-amd64.zip>
----
->   32-Bit: <https://dl.grafana.com/oss/release/grafana-7.1.1.windows-amd64.zip>
-15c15
-<   checksum32: 84961388ACDB8134E29558EF80AD989178BE95098808FB75DDD0AD3268BE570C
----
->   checksum32: DE586C6232CE9026DF097AFE3AF843F0097AB578409BE634F5BA4420FF3E786E
+  32-Bit: <https://dl.grafana.com/oss/release/grafana-7.1.1.windows-amd64.zip>
+  checksum32: DE586C6232CE9026DF097AFE3AF843F0097AB578409BE634F5BA4420FF3E786E
+  32-Bit: <https://dl.grafana.com/oss/release/grafana-7.1.0.windows-amd64.zip>
+  checksum32: 84961388ACDB8134E29558EF80AD989178BE95098808FB75DDD0AD3268BE570C
 Diff for \tools\chocolateyinstall.ps1:
-8c8
-<   file           = "$toolsdir\grafana-7.1.0.windows-amd64.zip"
----
->   file           = "$toolsdir\grafana-7.1.1.windows-amd64.zip"
+  file           = "$toolsdir\grafana-7.1.1.windows-amd64.zip"
+  file           = "$toolsdir\grafana-7.1.0.windows-amd64.zip"
 WARNING: \tools\grafana-7.1.0.windows-amd64.zip is binary, ignoring.
 Diff for \grafana.nuspec:
-5c5
-<     <version>7.1.0</version>
----
->     <version>7.1.1</version>
+    <version>7.1.1</version>
+    <version>7.1.0</version>
 WARNING: \tools\grafana-7.1.1.windows-amd64.zip is binary, ignoring.
-WARNING: Deleting downloaded files
 ```
 
 ### Example: single package ID as input
@@ -67,25 +72,21 @@ Latest approved and unapproved versions are selected automatically.
 
 ```powershell
 Import-Module .\chocolatey-diff\chocolatey-diff.psm1
-chocolatey-diff on  gh8_versiondetect [✘!?] took 44s
-❯ Get-ChocolateyPackageDiff elasticsearch
-WARNING: Downloading file from https://chocolatey.org/api/v2//package/elasticsearch/6.7.1
-WARNING: Downloading file from https://chocolatey.org/api/v2//package/elasticsearch/7.8.1
+PS > Get-ChocolateyPackageDiff elasticsearch
 Diff for \tools\chocolateyBeforeModify.ps1:
-1c1
-< elasticsearch-service.bat stop
----
-> 2a3,10
->
-> $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-> $unPath = Join-Path $toolsDir 'Uninstall-ChocolateyPath.psm1'
-> Import-Module $unPath
->
-> $version      = "7.8.1"
-> $binPath = Join-Path $toolsDir "elasticsearch-$($version)\bin"
-> Uninstall-ChocolateyPath $binPath 'Machine'
-...
-...
-WARNING: The \tools\Uninstall-ChocolateyPath.psm1 is new. Manual verification required
-WARNING: Deleting downloaded files
+$version      = "7.8.1"
+$version      = "7.8.0"
+Diff for \tools\chocolateyInstall.ps1:
+$url          = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.8.1-windows-x86_64.zip'
+$checksum     = '800720331e64f091f87bb5ca1755c948c75718cb3723497d861b28fab2067e7a'
+$version      = "7.8.1"
+$url          = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.8.0-windows-x86_64.zip'
+$checksum     = 'e6e8160fcb0837cf2d5602e9c5ecb637b9cb46b7e333dfd681f65a235eed85d4'
+$version      = "7.8.0"
+Diff for \tools\Uninstall-ChocolateyPath.psm1:
+Diff for \elasticsearch.nuspec:
+    <version>7.8.1</version>
+    <releaseNotes>https://www.elastic.co/guide/en/elasticsearch/reference/7.8/release-notes-7.8.1.html</releaseNotes>
+    <version>7.8.0</version>
+    <releaseNotes>https://www.elastic.co/guide/en/elasticsearch/reference/7.8/release-notes-7.8.0.html</releaseNotes>
 ```

--- a/Tests/Private/Get-ChangesRegexForFile.Tests.ps1
+++ b/Tests/Private/Get-ChangesRegexForFile.Tests.ps1
@@ -1,0 +1,68 @@
+#Requires -Modules chocolatey-diff
+
+Describe "Get-ChangesRegexForFile" {
+
+    AfterAll {
+        Remove-Item Env:\galleryUrl -ErrorAction SilentlyContinue
+    }
+
+    Context 'Normal Tests' {
+
+        #region Discovery
+        $testCases = @(
+            @{
+                Filename = 'TestDrive:\MyPackage.nuspec'
+                Result   = @(
+                    "<version>.*<\/version>",
+                    "<releaseNotes>.*<\/releaseNotes>"
+                )
+            }
+            @{
+                Filename = 'TestDrive:\chocolateyInstall.ps1'
+                Result   = @(
+                    "^[$]?\s*url(32|64)?\s*=\s*[\`"'].*[\`"']",
+                    "^[$]?\s*file(32|64)?\s*=\s*[\`"'].*[\`"']",
+                    "^[$]?\s*checksum(32|64)?\s*=\s*[\`"'].*[\`"']",
+                    "^[$]?\s*checksumType(32|64)?\s*=\s*[\`"'].*[\`"']",
+                    "^[$]version\s*=\s*[\`"'].*[\`"']"
+                )
+            }
+        )
+        #endregion Discovery
+
+        It 'Fetches the regexes for <Filename>' -TestCases $testCases {
+            Param($Filename, $Result)
+            $Regexes = InModuleScope 'chocolatey-diff' -Parameters @{
+                Filename = $Filename
+            } {
+                Param ($Filename)
+                Get-ChangesRegexForFile -Filename $Filename
+            }
+            $Regexes | Should -Not -BeNullOrEmpty
+            $Regexes | Should -HaveCount $Result.Count
+            $Regexes | Should -Be $Result
+        }
+    }
+    Context 'Unknown file Tests' {
+
+        #region Discovery
+        $testCases = @(
+            @{
+                Filename = 'TestDrive:\Helpers.ps1'
+                Result   = ''
+            }
+        )
+        #endregion Discovery
+
+        It 'Fetches the regexes for <Filename>' -TestCases $testCases {
+            Param($Filename, $Result)
+            $Regexes = InModuleScope 'chocolatey-diff' -Parameters @{
+                Filename = $Filename
+            } {
+                Param ($Filename)
+                Get-ChangesRegexForFile -Filename $Filename
+            }
+            $Regexes | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Private/Invoke-DiffTool.Tests.ps1
+++ b/Tests/Private/Invoke-DiffTool.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Invoke-DiffTool tests" {
             @{
                 Difftool = ''
                 Platform = 'Win32NT'
-                Expected = "C:\tools\cygwin\bin\diff.exe"
+                Expected = "C:\Program Files\Git\usr\bin\diff.exe"
             }
             @{
                 Difftool = 'C:\Program Files\KDiff3\bin\diff.exe'

--- a/chocolatey-diff/Private/Get-ChangesRegexForFile.ps1
+++ b/chocolatey-diff/Private/Get-ChangesRegexForFile.ps1
@@ -23,7 +23,7 @@ function Get-ChangesRegexForFile {
         [Parameter(Mandatory)][string] $FileName
     )
 
-    $knwonExtensions = @{
+    $knownExtensions = @{
         '.nuspec' = @(
             "<version>.*<\/version>",
             "<releaseNotes>.*<\/releaseNotes>"
@@ -55,8 +55,8 @@ function Get-ChangesRegexForFile {
 
     $exactFileName = Split-Path -Path $FileName -Leaf
 
-    if ($knwonExtensions.ContainsKey($extension)) {
-        return $knwonExtensions[$extension]
+    if ($knownExtensions.ContainsKey($extension)) {
+        return $knownExtensions[$extension]
     } elseif ($knownFiles.ContainsKey($exactFileName)) {
         return $knownFiles[$exactFileName]
     }

--- a/chocolatey-diff/Private/Get-ChangesRegexForFile.ps1
+++ b/chocolatey-diff/Private/Get-ChangesRegexForFile.ps1
@@ -1,0 +1,66 @@
+#Requires -version 6.0
+function Get-ChangesRegexForFile {
+    <#
+.SYNOPSIS
+    Returns a set of regular expressions for a known Chocolatey file.
+
+.DESCRIPTION
+    Returns a set of regular expressions for a known Chocolatey file.
+
+.OUTPUTS
+    System.String[] with regexes for a know Chocolatey file.
+
+.PARAMETER FileName
+    The name of the file. Only the filename with extension is expected.
+
+.EXAMPLE
+    PS > Get-ChangesRegexForFile -FileName chocolateyInstall.ps1
+    <TODO>
+#>
+    [OutputType([System.String[]],[System.String])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)][string] $FileName
+    )
+
+    $knwonExtensions = @{
+        '.nuspec' = @(
+            "<version>.*<\/version>",
+            "<releaseNotes>.*<\/releaseNotes>"
+        )
+    }
+
+    $knownFiles = @{
+        'chocolateyInstall.ps1'      = @(
+            "^[$]?\s*url(32|64)?\s*=\s*[\`"'].*[\`"']",
+            "^[$]?\s*file(32|64)?\s*=\s*[\`"'].*[\`"']",
+            "^[$]?\s*checksum(32|64)?\s*=\s*[\`"'].*[\`"']",
+            "^[$]?\s*checksumType(32|64)?\s*=\s*[\`"'].*[\`"']",
+            "^[$]version\s*=\s*[\`"'].*[\`"']"
+        )
+        # 'chocolateyUninstall.ps1' = @()
+        'chocolateyBeforeModify.ps1' = @(
+            "[$]?version.*"
+        )
+        'VERIFICATION.txt' = @(
+            "\s*url.*",
+            "\s*32-Bit.*",
+            "\s*64-Bit.*",
+            "\s*checksum.*",
+            "\s*checksumType.*"
+        )
+    }
+
+    $extension = Split-Path -Path $FileName -Extension
+
+    $exactFileName = Split-Path -Path $FileName -Leaf
+
+    if ($knwonExtensions.ContainsKey($extension)) {
+        return $knwonExtensions[$extension]
+    } elseif ($knownFiles.ContainsKey($exactFileName)) {
+        return $knownFiles[$exactFileName]
+    }
+
+    # Can't find a regex for this file, returning null
+    return ''
+}

--- a/chocolatey-diff/Private/Invoke-DiffTool.ps1
+++ b/chocolatey-diff/Private/Invoke-DiffTool.ps1
@@ -31,7 +31,7 @@ function Invoke-DiffTool {
     } elseif (Test-IsUnix) {
         "diff"
     } else {
-        "C:\tools\cygwin\bin\diff.exe"
+        "C:\Program Files\Git\usr\bin\diff.exe"
     }
     Write-Verbose "using difftool: $diffTool"
     Start-Process -NoNewWindow -Wait -FilePath $diffTool -ArgumentList "${Path1}", "${Path2}"

--- a/chocolatey-diff/Private/Invoke-DiffTool.ps1
+++ b/chocolatey-diff/Private/Invoke-DiffTool.ps1
@@ -6,7 +6,7 @@ function Invoke-DiffTool {
 .DESCRIPTION
     This function uses `$env:difftool` to create the diff of two files,
     if the difftool environment variable is not set, it will default
-    to `diff` on Unix OS and "diff.exe" from KDiff3 in its default
+    to `diff` on Unix OS and "diff.exe" from cygwin in its default
     install location on Windows OS.
 
 .PARAMETER Path1
@@ -23,18 +23,15 @@ function Invoke-DiffTool {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory)]
-        [string] $Path1,
-
-        [Parameter(Mandatory)]
-        [string] $Path2
+        [Parameter(Mandatory)][string] $Path1,
+        [Parameter(Mandatory)][string] $Path2
     )
     $diffTool = if ($env:difftool) {
         $env:difftool
     } elseif (Test-IsUnix) {
         "diff"
     } else {
-        "C:\Program Files\KDiff3\bin\diff.exe"
+        "C:\tools\cygwin\bin\diff.exe"
     }
     Write-Verbose "using difftool: $diffTool"
     Start-Process -NoNewWindow -Wait -FilePath $diffTool -ArgumentList "${Path1}", "${Path2}"

--- a/chocolatey-diff/chocolatey-diff.psd1
+++ b/chocolatey-diff/chocolatey-diff.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) 2020 Maurice Kevenaar. All rights reserved.'
 Description = 'A diff tool to aid Chocolatey moderators with their moderation process'
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '5.0.0'
+PowerShellVersion = '6.0'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''


### PR DESCRIPTION
Merging this will allow this package to ignore lines with expected output.

## Description
The script is changed to use `Compare-Object` instead of a separate diff tool. This gives us more control over the output and what lines should be ignored.

While I am aware that there may be more regex's to be added, I want to get this merged in as a basic setup

## Related Issue
Fixes #22 

## Motivation and Context
This will help moderators to verify what unexpected changes might be added to the packages

## How Has This Been Tested?
Tested on a couple of packages and by adding Pester tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
