### PR TITLE
(GH-30) Add ability to compare meta information of found binaries

### DIFF
--- a/Tests/Private/Get-PackageBinaryData.Tests.ps1
+++ b/Tests/Private/Get-PackageBinaryData.Tests.ps1
@@ -1,0 +1,4 @@
+#Requires -Modules chocolatey-diff
+
+Describe "Get-PackageBinaryData tests" {
+}

--- a/chocolatey-diff/Private/Get-PackageBinaryData.ps1
+++ b/chocolatey-diff/Private/Get-PackageBinaryData.ps1
@@ -1,0 +1,44 @@
+function Get-PackageBinaryData {
+    <#
+    .SYNOPSIS
+        The meta information about binaries included in package
+    .DESCRIPTION
+        The meta information about binaries included in the package, including
+        the relative path, the checksum of the file, the embedded file and product
+        version as well as the embedded company name.
+    .OUTPUTS
+        An array of hashtables with the basic information about each binary file.
+    .EXAMPLE
+        PS > Get-PackageBinaryData -packageDirectory path\to\package\dir
+    #>
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$packageDirectory,
+        [ValidateSet('sha1', 'sha256', 'sha512')]
+        [string]$hashAlgorithm = 'sha256'
+    )
+
+    Push-Location $packageDirectory | Out-Null
+
+    try {
+        Write-Verbose "Finding binary files in '$packageDirectory..."
+        $binaryFiles = Get-ChildItem -Path $packageDirectory -Recurse -File | ? { Test-IsBinary -Path $_.FullName }
+
+        foreach ($file in $binaryFiles) {
+            Write-Verbose "Aquiring binary data from $($file.Name)..."
+
+            $item = Get-Item $file.FullName
+            $result = @{
+                path           = Resolve-Path $file.FullName -Relative
+                checksum       = Get-FileHash $file.FullName -Algorithm $hashAlgorithm | % Hash
+                fileVersion    = $item.VersionInfo.FileVersion
+                productVersion = $item.VersionInfo.ProductVersion
+                CompanyName    = $item.VersionInfo.CompanyName
+            }
+            $result
+        }
+    } finally {
+
+        Pop-Location | Out-Null
+    }
+}

--- a/chocolatey-diff/Public/Get-ChocolateyPackageDiff.ps1
+++ b/chocolatey-diff/Public/Get-ChocolateyPackageDiff.ps1
@@ -48,29 +48,29 @@
     Get-ChocolateyPackageDiff -packageName chocolatey -oldPackageVersion 0.10.14 -newPackageVersion 0.10.15
 
 #>
-    [cmdletbinding(DefaultParameterSetName='Default')]
+    [cmdletbinding(DefaultParameterSetName = 'Default')]
     param(
-        [parameter(Mandatory = $true, Position = 0, ParameterSetName='Default')]
-        [parameter(Mandatory = $true, Position = 0, ParameterSetName='DiffTool')]
-            [string] $packageName,
-        [parameter(Mandatory = $false, Position = 1, ParameterSetName='Default')]
-        [parameter(Mandatory = $false, Position = 1, ParameterSetName='DiffTool')]
-            [string] $oldPackageVersion,
-        [parameter(Mandatory = $false, Position = 2, ParameterSetName='Default')]
-        [parameter(Mandatory = $false, Position = 2, ParameterSetName='DiffTool')]
-            [string] $newPackageVersion,
-        [parameter(Mandatory = $false, ParameterSetName='Default')]
-        [parameter(Mandatory = $false, ParameterSetName='DiffTool')]
-            [string] $downloadLocation = $(Get-TempPath),
-        [parameter(Mandatory = $false, ParameterSetName='Default')]
-        [parameter(Mandatory = $false, ParameterSetName='DiffTool')]
-            [switch] $keepFiles = $false,
-        [parameter(Mandatory = $false, 	ParameterSetName='Default')]
-            [switch] $ignoreExpectedChanges = $false,
-        [parameter(Mandatory = $false, ParameterSetName='DiffTool')]
-            [switch] $compareFolder = $false,
-        [parameter(Mandatory = $false, ParameterSetName='DiffTool')]
-            [switch] $useDiffTool = $false
+        [parameter(Mandatory = $true, Position = 0, ParameterSetName = 'Default')]
+        [parameter(Mandatory = $true, Position = 0, ParameterSetName = 'DiffTool')]
+        [string] $packageName,
+        [parameter(Mandatory = $false, Position = 1, ParameterSetName = 'Default')]
+        [parameter(Mandatory = $false, Position = 1, ParameterSetName = 'DiffTool')]
+        [string] $oldPackageVersion,
+        [parameter(Mandatory = $false, Position = 2, ParameterSetName = 'Default')]
+        [parameter(Mandatory = $false, Position = 2, ParameterSetName = 'DiffTool')]
+        [string] $newPackageVersion,
+        [parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [parameter(Mandatory = $false, ParameterSetName = 'DiffTool')]
+        [string] $downloadLocation = $(Get-TempPath),
+        [parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [parameter(Mandatory = $false, ParameterSetName = 'DiffTool')]
+        [switch] $keepFiles = $false,
+        [parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [switch] $ignoreExpectedChanges = $false,
+        [parameter(Mandatory = $false, ParameterSetName = 'DiffTool')]
+        [switch] $compareFolder = $false,
+        [parameter(Mandatory = $false, ParameterSetName = 'DiffTool')]
+        [switch] $useDiffTool = $false
     )
     $currentProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
@@ -106,6 +106,31 @@
     #Extract the package files
     Expand-Archive -Path $oldFileName -DestinationPath $oldExtractPath -Force
     Expand-Archive -Path $newFileName -DestinationPath $newExtractPath -Force
+
+    foreach ($path in @($oldExtractPath; $newExtractPath)) {
+        # Only because of unit tests
+        if (!(Test-Path $path)) { continue; }
+
+        $metaDestination = Join-Path $path "binary-data.txt"
+        Push-Location -Path $path
+        if (Test-Path $metaDestination) {
+            Remove-Item $metaDestination
+        }
+
+        Get-ChildItem -Path $path -Recurse -File | ? { Test-IsBinary -Path $_.FullName } | % {
+            $item = Get-Item $_.FullName
+            $result = @{
+                path           = Resolve-Path $_.FullName -Relative
+                checksum       = Get-FileHash $_.FullName -Algorithm SHA256 | % Hash
+                fileVersion    = $item.VersionInfo.FileVersion
+                productVersion = $item.VersionInfo.ProductVersion
+            }
+
+            $result
+        } | Out-File -Encoding utf8 -FilePath $metaDestination
+
+        Pop-Location
+    }
 
     if ($compareFolder) {
         # We need to remove files that should not be compared

--- a/chocolatey-diff/Public/Get-ChocolateyPackageDiff.ps1
+++ b/chocolatey-diff/Public/Get-ChocolateyPackageDiff.ps1
@@ -108,28 +108,16 @@
     Expand-Archive -Path $newFileName -DestinationPath $newExtractPath -Force
 
     foreach ($path in @($oldExtractPath; $newExtractPath)) {
-        # Only because of unit tests
+        # Temporary workaround until mocking and unit tests
+        # are figured out.
         if (!(Test-Path $path)) { continue; }
 
         $metaDestination = Join-Path $path "binary-data.txt"
-        Push-Location -Path $path
         if (Test-Path $metaDestination) {
             Remove-Item $metaDestination
         }
 
-        Get-ChildItem -Path $path -Recurse -File | ? { Test-IsBinary -Path $_.FullName } | % {
-            $item = Get-Item $_.FullName
-            $result = @{
-                path           = Resolve-Path $_.FullName -Relative
-                checksum       = Get-FileHash $_.FullName -Algorithm SHA256 | % Hash
-                fileVersion    = $item.VersionInfo.FileVersion
-                productVersion = $item.VersionInfo.ProductVersion
-            }
-
-            $result
-        } | Out-File -Encoding utf8 -FilePath $metaDestination
-
-        Pop-Location
+        Get-PackageBinaryData -packageDirectory $path | Out-File -Encoding utf8 -FilePath $metaDestination
     }
 
     if ($compareFolder) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull requests adds the ability to store and compare basic information of the included binary files in each package version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #30

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To be able to easier notice the changes regarding binary files between each version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Currently only been tested in a remote devcontainer in vscode.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (_maybe?_)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (_not added yet, need help to figure out how to test the changes_)
- [x] All new and existing tests passed.

### Additional

This pull request is currently a WIP, unit tests have not yet been added nor completely tested appropriately.
Wanted to get some feedback on the current implementation before going any further with this one.

example output:
```console
PS /workspaces/chocodiff> cat /tmp/chocodiff/7zip.install.18.6/binary-data.txt


Name                           Value
----                           -----
path                           ./tools/7zip_x32.exe
checksum                       7A2E78C5C2EBC072088B7D8DFF6E00D414E7084C97C2C730CC4C45905668A8F3
CompanyName                    
fileVersion                    
productVersion                 
path                           ./tools/7zip_x64.exe
checksum                       18D0BF6A9A2BC4DD0779B5FCEFE0AA893F938419D755FE9BC6DBFA50D94BD488
CompanyName                    
fileVersion                    
productVersion 
```