### PR TITLE
Development container for Visual Studio Code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,5 @@
 FROM mcr.microsoft.com/powershell:lts-debian-10
 
-# [Option] Install zsh
-ARG INSTALL_ZSH="true"
-# [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,13 +13,3 @@ COPY library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update \
     && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
-
-USER vscode
-
-# [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-RUN pwsh  -Command 'Install-Package PSScriptAnalyzer -Force -Confirm:$false' \
-    && pwsh -Command 'Install-Package PSake -Force -Confirm:$false' \
-    && pwsh -Command 'Install-Package BuildHelpers -Force -Confirm:$false' \
-    && pwsh -Command 'Install-Package Pester -Force -Confirm:$false'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/powershell:lts-debian-10
+
+# [Option] Install zsh
+ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="false"
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+COPY library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update \
+    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+USER vscode
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN pwsh  -Command 'Install-Package PSScriptAnalyzer -Force -Confirm:$false' \
+    && pwsh -Command 'Install-Package PSake -Force -Confirm:$false' \
+    && pwsh -Command 'Install-Package BuildHelpers -Force -Confirm:$false' \
+    && pwsh -Command 'Install-Package Pester -Force -Confirm:$false'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Uncomment the next line to run commands after the container is created. This gets run in bash which is why we call `pwsh`.
-	// "postCreateCommand": "pwsh -c '$PSVersionTable'",
+	"postCreateCommand": "pwsh -c './build.ps1 -Task Clean -Bootstrap'",
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/powershell
+{
+	"name": "PowerShell",
+	"dockerFile": "Dockerfile",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/usr/bin/pwsh"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.powershell",
+		"davidanson.vscode-markdownlint",
+		"ryanluker.vscode-coverage-gutters"
+	],
+	"build": {
+		"args": {
+			"UPGRADE_PACKAGES": "true"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Uncomment the next line to run commands after the container is created. This gets run in bash which is why we call `pwsh`.
+	// "postCreateCommand": "pwsh -c '$PSVersionTable'",
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,6 @@
 		"davidanson.vscode-markdownlint",
 		"ryanluker.vscode-coverage-gutters"
 	],
-	"build": {
-		"args": {
-			"UPGRADE_PACKAGES": "true"
-		}
-	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Uncomment the next line to run commands after the container is created. This gets run in bash which is why we call `pwsh`.

--- a/.devcontainer/library-scripts/common-debian.sh
+++ b/.devcontainer/library-scripts/common-debian.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag]
+
+INSTALL_ZSH=${1:-"true"}
+USERNAME=${2:-"vscode"}
+USER_UID=${3:-1000}
+USER_GID=${4:-1000}
+UPGRADE_PACKAGES=${5:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" as root
+if [ "${USERNAME}" = "none" ] || [ "${USERNAME}" = "root" ]; then
+    USERNAME=root
+    USER_UID=0
+    USER_GID=0
+fi
+
+# Load markers to see which steps have already run
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
+if [ -f "${MARKER_FILE}" ]; then
+    echo "Marker file found:"
+    cat "${MARKER_FILE}"
+    source "${MARKER_FILE}"
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to call apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
+if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
+    apt-get-update-if-needed
+
+    PACKAGE_LIST="apt-utils \
+        git \
+        openssh-client \
+        gnupg2 \
+        iproute2 \
+        procps \
+        lsof \
+        htop \
+        net-tools \
+        psmisc \
+        curl \
+        wget \
+        rsync \
+        ca-certificates \
+        unzip \
+        zip \
+        nano \
+        vim-tiny \
+        less \
+        jq \
+        lsb-release \
+        apt-transport-https \
+        dialog \
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu[0-9][0-9] \
+        liblttng-ust0 \
+        libstdc++6 \
+        zlib1g \
+        locales \
+        sudo \
+        ncdu \
+        man-db"
+
+    # Install libssl1.1 if available
+    if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
+        PACKAGE_LIST="${PACKAGE_LIST}       libssl1.1"
+    fi
+
+    # Install appropriate version of libssl1.0.x if available
+    LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
+    if [ "$(echo "$LIBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
+        if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
+            # Debian 9
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.2"
+        elif [[ ! -z $(apt-cache --names-only search ^libssl1.0.0$) ]]; then
+            # Ubuntu 18.04, 16.04, earlier
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.0"
+        fi
+    fi
+
+    echo "Packages to verify are installed: ${PACKAGE_LIST}"
+    apt-get -y install --no-install-recommends ${PACKAGE_LIST} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+
+    PACKAGES_ALREADY_INSTALLED="true"
+fi
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt-get-update-if-needed
+    apt-get -y upgrade --no-install-recommends
+    apt-get autoremove -y
+fi
+
+# Ensure at least the en_US.UTF-8 UTF-8 locale is available.
+# Common need for both applications and things like the agnoster ZSH theme.
+if [ "${LOCALE_ALREADY_SET}" != "true" ]; then
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    locale-gen
+    LOCALE_ALREADY_SET="true"
+fi
+
+# Create or update a non-root user to match UID/GID - see https://aka.ms/vscode-remote/containers/non-root-user.
+if id -u $USERNAME > /dev/null 2>&1; then
+    # User exists, update if needed
+    if [ "$USER_GID" != "$(id -G $USERNAME)" ]; then
+        groupmod --gid $USER_GID $USERNAME
+        usermod --gid $USER_GID $USERNAME
+    fi
+    if [ "$USER_UID" != "$(id -u $USERNAME)" ]; then
+        usermod --uid $USER_UID $USERNAME
+    fi
+else
+    # Create user
+    groupadd --gid $USER_GID $USERNAME
+    useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
+fi
+
+# Add add sudo support for non-root user
+if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}" ]; then
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+    chmod 0440 /etc/sudoers.d/$USERNAME
+    EXISTING_NON_ROOT_USER="${USERNAME}"
+fi
+
+# .bashrc/.zshrc snippet
+RC_SNIPPET="$(cat << EOF
+export USER=\$(whoami)
+
+export PATH=\$PATH:\$HOME/.local/bin
+
+if [[ \$(which code-insiders 2>&1) && ! \$(which code 2>&1) ]]; then
+    alias code=code-insiders
+fi
+EOF
+)"
+
+# Ensure ~/.local/bin is in the PATH for root and non-root users for bash. (zsh is later)
+if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
+    echo "${RC_SNIPPET}" >> /etc/bash.bashrc
+    RC_SNIPPET_ALREADY_ADDED="true"
+fi
+
+# Optionally install and configure zsh
+if [ "${INSTALL_ZSH}" = "true" ] && [ ! -d "/root/.oh-my-zsh" ] && [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+    apt-get-update-if-needed
+    apt-get install -y zsh
+    curl -fsSLo- https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash 2>&1
+    echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
+    echo -e "DEFAULT_USER=\$USER\nprompt_context(){}" >> /root/.zshrc
+    cp -fR /root/.oh-my-zsh /etc/skel
+    cp -f /root/.zshrc /etc/skel
+    sed -i -e "s/\/root\/.oh-my-zsh/\/home\/\$(whoami)\/.oh-my-zsh/g" /etc/skel/.zshrc
+    if [ "${USERNAME}" != "root" ]; then
+        cp -fR /etc/skel/.oh-my-zsh /etc/skel/.zshrc /home/$USERNAME
+        chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
+    fi
+    ZSH_ALREADY_INSTALLED="true"
+fi
+
+# Write marker file
+mkdir -p "$(dirname "${MARKER_FILE}")"
+echo -e "\
+    PACKAGES_ALREADY_INSTALLED=${PACKAGES_ALREADY_INSTALLED}\n\
+    LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
+    EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
+    RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
+    ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
+
+echo "Done!"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This pull request adds a development container that can be used together with Visual Studio Code+Remote Container (or with GitHub CodeSpaces).

The container is set up using the existing PowerShell container from microsoft (PowerShell V7), and runs in a non-root file system, as well as installing the necessary requirements as part of a post creation task.
Additionally, the container sets PowerShell Core as the default shell, and installs the three recommended visual studio code extensions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related issues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To have a common ground for development of the powershell module.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using a local instance of visual studio code, and its integrated terminal.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Build Related

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
